### PR TITLE
Support collapsed thread and no message pane case

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "2.0",
+  "version": "2.1",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [


### PR DESCRIPTION
`browser.messageDisplay.getDisplayedMessage()` returns nothing if the selected thread is collapsed or the message pane is hidden, so we need to fallback to `browser.mailTabs.getSelectedMessages()`.

Note that we still need to use the old method for message windows without thread pane.

